### PR TITLE
Avoiding BE secret colision and changing etcd-druid bootstraping

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -20,7 +20,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.4.1"
+  tag: "v0.5.0-dev-cpm-poc"
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -16,6 +16,7 @@ package genericactuator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,10 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+const (
+	AnnotationSource = "backupentry.gardener.cloud/source"
 )
 
 type actuator struct {
@@ -89,9 +94,14 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, be *extensionsv1a
 		return err
 	}
 
+	backupBucketName := BackupSecretName
+	if be.Annotations[AnnotationSource] == "true" {
+		backupBucketName = fmt.Sprintf("%s-%s", "source", BackupSecretName)
+	}
+
 	etcdSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BackupSecretName,
+			Name:      backupBucketName,
 			Namespace: shootTechnicalID,
 		},
 	}

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -31,6 +31,7 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	coordination "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -124,6 +125,11 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 					Verbs:     []string{"get", "list", "patch", "update", "watch", "create", "delete"},
 				},
 				{
+					APIGroups: []string{coordination.GroupName},
+					Resources: []string{"leases"},
+					Verbs:     []string{"get", "list", "patch", "update", "watch", "create", "delete"},
+				},
+				{
 					APIGroups: []string{druidv1alpha1.GroupVersion.Group},
 					Resources: []string{"etcds"},
 					Verbs:     []string{"get", "list", "watch", "update", "patch"},
@@ -213,7 +219,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 							{
 								Name:            Druid,
 								Image:           b.image,
-								ImagePullPolicy: corev1.PullIfNotPresent,
+								ImagePullPolicy: corev1.PullAlways,
 								Command: []string{
 									"/bin/etcd-druid",
 									"--enable-leader-election=true",


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Check for `backupentry.is.copy=true` annotation and set the `etcd-backup` secret name appropriately to avoid collision.
1. Prepare `ETCD-druid` for proper testing by changing its version to the `dev` build, so that the resource manager will deploy . Also, the `imagePullPolicy` is changed to `Always` and additional cluster role for `leases` is created to avoid leader election problems. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
