### PR TITLE
Adds deployment of a Source BackupEntry and handling to copy backup buckets

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,6 +11,7 @@ images:
 - name: gardener-seed-admission-controller
   sourceRepository: github.com/gardener/gardener
   repository: eu.gcr.io/gardener-project/gardener/seed-admission-controller
+  tag: "v1.21.0"
 
 # Seed bootstrap
 - name: pause-container

--- a/extensions/pkg/controller/backupentry/genericactuator/types.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/types.go
@@ -23,6 +23,8 @@ import (
 const (
 	// BackupSecretName is the name of secret having credentials for etcd backups.
 	BackupSecretName string = "etcd-backup"
+	//SourceBackupSecretName is the name of the secret having credentials for the source etcd backups used in the copy operation
+	SourceBackupSecretName string = "source-etcd-backup"
 	// DataKeyBackupBucketName is the name of a data key whose value contains the backup bucket name.
 	DataKeyBackupBucketName string = "bucketName"
 )

--- a/pkg/apis/core/validation/backupentry.go
+++ b/pkg/apis/core/validation/backupentry.go
@@ -56,7 +56,7 @@ func ValidateBackupEntrySpec(spec *core.BackupEntrySpec, fldPath *field.Path) fi
 func ValidateBackupEntrySpecUpdate(newSpec, oldSpec *core.BackupEntrySpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.BucketName, oldSpec.BucketName, fldPath.Child("bucketName"))...)
+	//allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.BucketName, oldSpec.BucketName, fldPath.Child("bucketName"))...)
 
 	return allErrs
 }

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -64,7 +64,6 @@ type actuator struct {
 
 func newActuator(gardenClient, seedClient kubernetes.Interface, be *gardencorev1beta1.BackupEntry, logger logrus.FieldLogger) Actuator {
 	extensionSecret := emptyExtensionSecret(be)
-
 	return &actuator{
 		logger:       logger.WithField("backupentry", be.Name),
 		gardenClient: gardenClient,
@@ -81,6 +80,7 @@ func newActuator(gardenClient, seedClient kubernetes.Interface, be *gardencorev1
 					Name:      extensionSecret.Name,
 					Namespace: extensionSecret.Namespace,
 				},
+				IsSource: metav1.HasAnnotation(be.ObjectMeta, "backupentry.gardener.cloud/source"),
 			},
 			extensionsbackupentry.DefaultInterval,
 			extensionsbackupentry.DefaultSevereThreshold,

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -406,6 +406,10 @@ func (c *Controller) reconcileShoot(ctx context.Context, logger *logrus.Entry, g
 		reconcileAllowed                           = !failedOrIgnored && ((!reconcileInMaintenanceOnly && !confineSpecUpdateRollout(shoot.Spec.Maintenance)) || !isUpToDate || (isNowInEffectiveShootMaintenanceTimeWindow && !alreadyReconciledDuringThisTimeWindow))
 	)
 
+	if operationType == gardencorev1beta1.LastOperationTypeMigrate {
+		return reconcile.Result{}, fmt.Errorf("operation %s is not allowed during Shoot reconciliation", operationType)
+	}
+
 	if !controllerutil.ContainsFinalizer(shoot, gardencorev1beta1.GardenerName) {
 		if err := controllerutils.PatchAddFinalizers(ctx, gardenClient.Client(), shoot.DeepCopy(), gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not add finalizer to Shoot: %s", err.Error())

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -70,11 +70,11 @@ func (c *Controller) prepareShootForMigration(ctx context.Context, logger *logru
 		return reconcile.Result{}, utilerrors.WithSuppressed(operationErr, updateErr)
 	}
 
-	if flowErr := c.runPrepareShootControlPlaneMigration(o); flowErr != nil {
-		c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventMigrationPreparationFailed, flowErr.Description)
-		_, updateErr := c.updateShootStatusOperationError(ctx, gardenClient, o.Shoot.Info, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
-		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(flowErr.Description), updateErr)
-	}
+	// if flowErr := c.runPrepareShootControlPlaneMigration(o); flowErr != nil {
+	// 	c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventMigrationPreparationFailed, flowErr.Description)
+	// 	_, updateErr := c.updateShootStatusOperationError(ctx, gardenClient, o.Shoot.Info, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
+	// 	return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(flowErr.Description), updateErr)
+	// }
 
 	return c.finalizeShootPrepareForMigration(ctx, gardenClient, shoot, o)
 }
@@ -298,13 +298,6 @@ func (c *Controller) finalizeShootPrepareForMigration(ctx context.Context, garde
 			_, updateErr := c.updateShootStatusOperationError(ctx, gardenClient, shoot, lastErr.Description, gardencorev1beta1.LastOperationTypeMigrate, *lastErr)
 			return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(lastErr.Description), updateErr)
 		}
-	}
-
-	if err := o.SwitchBackupEntryToTargetSeed(ctx); err != nil {
-		lastErr := gardencorev1beta1helper.LastError(fmt.Sprintf("Could not switch BackupEntry resource in Garden to new Seed: %s", err))
-		c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastErr.Description)
-		_, updateErr := c.updateShootStatusOperationError(ctx, gardenClient, shoot, lastErr.Description, gardencorev1beta1.LastOperationTypeMigrate, *lastErr)
-		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(lastErr.Description), updateErr)
 	}
 
 	c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventMigrationPrepared, "Shoot Control Plane prepared for migration, successfully")

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -74,7 +74,7 @@ func (b *Botanist) GenerateKubernetesDashboardConfig() (map[string]interface{}, 
 // EnsureIngressDNSRecord deploys the nginx ingress DNSEntry and DNSOwner resources.
 func (b *Botanist) EnsureIngressDNSRecord(ctx context.Context) error {
 	if b.NeedsExternalDNS() && !b.Shoot.HibernationEnabled && gardencorev1beta1helper.NginxIngressEnabled(b.Shoot.Info.Spec.Addons) {
-		if b.isRestorePhase() {
+		if b.IsRestorePhase() {
 			return dnsRestoreDeployer{
 				entry: b.Shoot.Components.Extensions.DNS.NginxEntry,
 				owner: b.Shoot.Components.Extensions.DNS.NginxOwner,

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -113,6 +113,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	if err != nil {
 		return nil, err
 	}
+	o.Shoot.Components.ControlPlane.EtcdForCopy = b.EtcdForCopy(v1beta1constants.ETCDRoleMain, etcd.ClassImportant)
 	o.Shoot.Components.ControlPlane.KubeAPIServerService = b.DefaultKubeAPIServerService(sniPhase)
 	o.Shoot.Components.ControlPlane.KubeAPIServerSNI = b.DefaultKubeAPIServerSNI()
 	o.Shoot.Components.ControlPlane.KubeAPIServerSNIPhase = sniPhase
@@ -146,6 +147,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 
 	// other components
 	o.Shoot.Components.BackupEntry = b.DefaultCoreBackupEntry(b.K8sGardenClient.DirectClient())
+	o.Shoot.Components.SourceBackupEntry = b.SourceCoreBackupEntry(b.K8sGardenClient.DirectClient())
 	o.Shoot.Components.ClusterIdentity = clusteridentity.New(o.Shoot.Info.Status.ClusterIdentity, o.GardenClusterIdentity, o.Shoot.Info.Name, o.Shoot.Info.Namespace, o.Shoot.SeedNamespace, string(o.Shoot.Info.Status.UID), b.K8sGardenClient.DirectClient(), b.K8sSeedClient.DirectClient(), b.Logger)
 
 	return b, nil

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -426,6 +426,29 @@ spec:
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
                   type: object
+                sourceStore:
+                  description: SourceStore defines the specification of the source object store provider for copying backups.
+                  properties:
+                    container:
+                      type: string
+                    prefix:
+                      type: string
+                    provider:
+                      description: StorageProvider defines the type of object store provider for storing backups.
+                      type: string
+                    secretRef:
+                      description: SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace
+                      properties:
+                        name:
+                          description: Name is unique within a namespace to reference a secret resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the secret name must be unique.
+                          type: string
+                      type: object
+                  required:
+                  - prefix
+                  type: object
                 store:
                   description: Store defines the specification of object store provider
                     for storing backups.

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -110,6 +110,8 @@ type Etcd interface {
 	SetSecrets(Secrets)
 	// SetBackupConfig sets the backup configuration.
 	SetBackupConfig(config *BackupConfig)
+	// SetSourceBackupConfig sets the source backup configuration.
+	SetSourceBackupConfig(config *BackupConfig)
 	// SetHVPAConfig sets the HVPA configuration.
 	SetHVPAConfig(config *HVPAConfig)
 }
@@ -132,6 +134,10 @@ func New(
 		retainReplicas:          retainReplicas,
 		storageCapacity:         storageCapacity,
 		defragmentationSchedule: defragmentationSchedule,
+
+		waitInterval:        5 * time.Second,
+		waitSevereThreshold: 3 * time.Minute,
+		waitTimeout:         5 * time.Minute,
 	}
 }
 
@@ -144,9 +150,14 @@ type etcd struct {
 	storageCapacity         string
 	defragmentationSchedule *string
 
-	secrets      Secrets
-	backupConfig *BackupConfig
-	hvpaConfig   *HVPAConfig
+	secrets            Secrets
+	backupConfig       *BackupConfig
+	sourceBackupConfig *BackupConfig
+	hvpaConfig         *HVPAConfig
+
+	waitInterval        time.Duration
+	waitSevereThreshold time.Duration
+	waitTimeout         time.Duration
 }
 
 func (e *etcd) Deploy(ctx context.Context) error {
@@ -336,11 +347,21 @@ func (e *etcd) Deploy(ctx context.Context) error {
 				SecretRef: &corev1.SecretReference{Name: e.backupConfig.SecretRefName},
 				Container: &e.backupConfig.Container,
 				Provider:  &provider,
-				Prefix:    fmt.Sprintf("%s/etcd-%s", e.backupConfig.Prefix, e.role),
+				Prefix:    fmt.Sprintf("%s/etcd-%s", e.backupConfig.Prefix, v1beta1constants.ETCDRoleMain),
 			}
 			etcd.Spec.Backup.FullSnapshotSchedule = e.computeFullSnapshotSchedule(foundEtcd, existingEtcd)
 			etcd.Spec.Backup.DeltaSnapshotPeriod = &deltaSnapshotPeriod
 			etcd.Spec.Backup.DeltaSnapshotMemoryLimit = &deltaSnapshotMemoryLimit
+		}
+
+		if e.sourceBackupConfig != nil {
+			provider := druidv1alpha1.StorageProvider(e.sourceBackupConfig.Provider)
+			etcd.Spec.Backup.SourceStore = &druidv1alpha1.StoreSpec{
+				SecretRef: &corev1.SecretReference{Name: e.sourceBackupConfig.SecretRefName},
+				Container: &e.sourceBackupConfig.Container,
+				Provider:  &provider,
+				Prefix:    fmt.Sprintf("%s/etcd-%s", e.sourceBackupConfig.Prefix, v1beta1constants.ETCDRoleMain),
+			}
 		}
 
 		etcd.Spec.StorageCapacity = &storageCapacity
@@ -581,9 +602,10 @@ func (e *etcd) ServiceDNSNames() []string {
 	)
 }
 
-func (e *etcd) SetSecrets(secrets Secrets)                 { e.secrets = secrets }
-func (e *etcd) SetBackupConfig(backupConfig *BackupConfig) { e.backupConfig = backupConfig }
-func (e *etcd) SetHVPAConfig(hvpaConfig *HVPAConfig)       { e.hvpaConfig = hvpaConfig }
+func (e *etcd) SetSecrets(secrets Secrets)                       { e.secrets = secrets }
+func (e *etcd) SetBackupConfig(backupConfig *BackupConfig)       { e.backupConfig = backupConfig }
+func (e *etcd) SetSourceBackupConfig(backupConfig *BackupConfig) { e.sourceBackupConfig = backupConfig }
+func (e *etcd) SetHVPAConfig(hvpaConfig *HVPAConfig)             { e.hvpaConfig = hvpaConfig }
 
 func (e *etcd) podLabelSelector() labels.Selector {
 	app, _ := labels.NewRequirement(v1beta1constants.LabelApp, selection.Equals, []string{LabelAppValue})

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -144,6 +144,18 @@ func (mr *MockEtcdMockRecorder) SetSecrets(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecrets", reflect.TypeOf((*MockEtcd)(nil).SetSecrets), arg0)
 }
 
+// SetSourceBackupConfig mocks base method.
+func (m *MockEtcd) SetSourceBackupConfig(arg0 *etcd.BackupConfig) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSourceBackupConfig", arg0)
+}
+
+// SetSourceBackupConfig indicates an expected call of SetSourceBackupConfig.
+func (mr *MockEtcdMockRecorder) SetSourceBackupConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSourceBackupConfig", reflect.TypeOf((*MockEtcd)(nil).SetSourceBackupConfig), arg0)
+}
+
 // Snapshot mocks base method.
 func (m *MockEtcd) Snapshot(arg0 context.Context, arg1 kubernetes.PodExecutor) error {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/etcd/waiter.go
+++ b/pkg/operation/botanist/component/etcd/waiter.go
@@ -26,12 +26,60 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (e *etcd) Wait(_ context.Context) error        { return nil }
-func (e *etcd) WaitCleanup(_ context.Context) error { return nil }
+func (e *etcd) Wait(ctx context.Context) error {
+	var retryCountUntilSevere int
+
+	return retry.UntilTimeout(ctx, e.waitInterval, e.waitTimeout, func(ctx context.Context) (bool, error) {
+		var err error
+
+		retryCountUntilSevere++
+
+		etcd := &druidv1alpha1.Etcd{}
+		if err = e.client.Get(ctx, client.ObjectKey{Name: Name(e.role), Namespace: e.namespace}, etcd); err != nil {
+			return retry.MinorError(err)
+		}
+
+		switch {
+		case etcd.Status.LastError != nil:
+			return retry.MinorOrSevereError(retryCountUntilSevere, int(e.waitSevereThreshold.Nanoseconds()/e.waitInterval.Nanoseconds()), fmt.Errorf("%s reconciliation errored: %s", etcd.Name, *etcd.Status.LastError))
+		case etcd.DeletionTimestamp != nil:
+			err = fmt.Errorf("%s unexpectedly has a deletion timestamp", etcd.Name)
+		case etcd.Status.ObservedGeneration == nil || etcd.Generation != *etcd.Status.ObservedGeneration:
+			err = fmt.Errorf("%s reconciliation pending", etcd.Name)
+		case metav1.HasAnnotation(etcd.ObjectMeta, v1beta1constants.GardenerOperation):
+			err = fmt.Errorf("%s reconciliation in process", etcd.Name)
+		case !utils.IsTrue(etcd.Status.Ready):
+			err = fmt.Errorf("%s is not ready yet", etcd.Name)
+		}
+
+		if err == nil {
+			return retry.Ok()
+		}
+		return retry.MinorError(err)
+	})
+}
+
+func (e *etcd) WaitCleanup(ctx context.Context) error {
+	return retry.UntilTimeout(ctx, e.waitInterval, e.waitTimeout, func(ctx context.Context) (done bool, err error) {
+		etcd := &druidv1alpha1.Etcd{}
+		if err := e.client.Get(ctx, client.ObjectKey{Name: Name(e.role), Namespace: e.namespace}, etcd); err != nil {
+			if apierrors.IsNotFound(err) {
+				return retry.Ok()
+			}
+			return retry.SevereError(err)
+		}
+
+		if etcd.Status.LastError != nil {
+			return retry.MinorError(fmt.Errorf("could not delete etcd %s: last error is %s", etcd.Name, *etcd.Status.LastError))
+		}
+		return retry.MinorError(fmt.Errorf("etcd %s is still present", etcd.Name))
+	})
+}
 
 // WaitUntilEtcdsReady waits until all etcds in the given namespace are ready.
 func WaitUntilEtcdsReady(

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
@@ -70,6 +70,8 @@ type Values struct {
 	BucketName string
 	// BackupBucketProviderStatus is the optional provider status of the BackupBucket.
 	BackupBucketProviderStatus *runtime.RawExtension
+	// IsSource indicates whether this backupentry is used as a source during copy of ETCD Backups.
+	IsSource bool
 }
 
 // New creates a new instance of Interface.
@@ -109,6 +111,9 @@ func (b *backupEntry) Deploy(ctx context.Context) error {
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, b.client, backupEntry, func() error {
+		if b.values.IsSource {
+			metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, "backupentry.gardener.cloud/source", "true")
+		}
 		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -40,7 +40,7 @@ func (b *Botanist) DefaultContainerRuntime(seedClient client.Client) containerru
 // DeployContainerRuntime deploys the ContainerRuntime custom resources and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployContainerRuntime(ctx context.Context) error {
-	if b.isRestorePhase() {
+	if b.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.ContainerRuntime.Restore(ctx, b.ShootState)
 	}
 	return b.Shoot.Components.Extensions.ContainerRuntime.Deploy(ctx)

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -354,7 +354,7 @@ func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 }
 
 func (b *Botanist) deployOrRestoreControlPlane(ctx context.Context, controlPlane extensionscontrolplane.Interface) error {
-	if b.isRestorePhase() {
+	if b.IsRestorePhase() {
 		return controlPlane.Restore(ctx, b.ShootState)
 	}
 	return controlPlane.Deploy(ctx)

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -49,7 +49,7 @@ const (
 // DeployExternalDNS deploys the external DNSOwner, DNSProvider, and DNSEntry resources.
 func (b *Botanist) DeployExternalDNS(ctx context.Context) error {
 	if b.NeedsExternalDNS() {
-		if b.isRestorePhase() {
+		if b.IsRestorePhase() {
 			return dnsRestoreDeployer{
 				provider: b.Shoot.Components.Extensions.DNS.ExternalProvider,
 				entry:    b.Shoot.Components.Extensions.DNS.ExternalEntry,
@@ -74,7 +74,7 @@ func (b *Botanist) DeployExternalDNS(ctx context.Context) error {
 // DeployInternalDNS deploys the internal DNSOwner, DNSProvider, and DNSEntry resources.
 func (b *Botanist) DeployInternalDNS(ctx context.Context) error {
 	if b.NeedsInternalDNS() {
-		if b.isRestorePhase() {
+		if b.IsRestorePhase() {
 			return dnsRestoreDeployer{
 				provider: b.Shoot.Components.Extensions.DNS.InternalProvider,
 				entry:    b.Shoot.Components.Extensions.DNS.InternalEntry,

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -55,7 +55,7 @@ func (b *Botanist) DefaultExtension(ctx context.Context, seedClient client.Clien
 // DeployExtensions deploys the Extension custom resources and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployExtensions(ctx context.Context) error {
-	if b.isRestorePhase() {
+	if b.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Extension.Restore(ctx, b.ShootState)
 	}
 	return b.Shoot.Components.Extensions.Extension.Deploy(ctx)

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -36,7 +36,7 @@ func (b *Botanist) DefaultInfrastructure(seedClient client.Client) infrastructur
 			Type:              b.Shoot.Info.Spec.Provider.Type,
 			ProviderConfig:    b.Shoot.Info.Spec.Provider.InfrastructureConfig,
 			Region:            b.Shoot.Info.Spec.Region,
-			AnnotateOperation: controllerutils.HasTask(b.Shoot.Info.Annotations, v1beta1constants.ShootTaskDeployInfrastructure) || b.isRestorePhase(),
+			AnnotateOperation: controllerutils.HasTask(b.Shoot.Info.Annotations, v1beta1constants.ShootTaskDeployInfrastructure) || b.IsRestorePhase(),
 		},
 		infrastructure.DefaultInterval,
 		infrastructure.DefaultSevereThreshold,
@@ -49,7 +49,7 @@ func (b *Botanist) DefaultInfrastructure(seedClient client.Client) infrastructur
 func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
 	b.Shoot.Components.Extensions.Infrastructure.SetSSHPublicKey(b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys])
 
-	if b.isRestorePhase() {
+	if b.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Infrastructure.Restore(ctx, b.ShootState)
 	}
 

--- a/pkg/operation/botanist/migration.go
+++ b/pkg/operation/botanist/migration.go
@@ -51,7 +51,7 @@ func (b *Botanist) runParallelTaskForEachExtensionComponent(ctx context.Context,
 	return flow.Parallel(fns...)(ctx)
 }
 
-func (b *Botanist) isRestorePhase() bool {
+func (b *Botanist) IsRestorePhase() bool {
 	return b.Shoot != nil &&
 		b.Shoot.Info != nil &&
 		b.Shoot.Info.Status.LastOperation != nil &&

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -45,7 +45,7 @@ func (b *Botanist) DefaultNetwork(seedClient client.Client) component.DeployMigr
 // DeployNetwork deploys the Network custom resource and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployNetwork(ctx context.Context) error {
-	if b.isRestorePhase() {
+	if b.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Network.Restore(ctx, b.ShootState)
 	}
 

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -89,7 +89,7 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetKubeletCACertificate(string(b.Secrets[v1beta1constants.SecretNameCAKubelet].Data[secrets.DataKeyCertificateCA]))
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetSSHPublicKey(string(b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys]))
 
-	if b.isRestorePhase() {
+	if b.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.OperatingSystemConfig.Restore(ctx, b.ShootState)
 	}
 

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -60,7 +60,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 	b.Shoot.Components.Extensions.Worker.SetInfrastructureProviderStatus(b.Shoot.Components.Extensions.Infrastructure.ProviderStatus())
 	b.Shoot.Components.Extensions.Worker.SetWorkerNameToOperatingSystemConfigsMap(b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerNameToOperatingSystemConfigsMap())
 
-	if b.isRestorePhase() {
+	if b.IsRestorePhase() {
 		return b.Shoot.Components.Extensions.Worker.Restore(ctx, b.ShootState)
 	}
 

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -533,24 +533,6 @@ func (o *Operation) DeleteClusterResourceFromSeed(ctx context.Context) error {
 	return client.IgnoreNotFound(o.K8sSeedClient.Client().Delete(ctx, &extensionsv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: o.Shoot.SeedNamespace}}))
 }
 
-// SwitchBackupEntryToTargetSeed changes the BackupEntry in the Garden cluster to the Target Seed and removes it from the Source Seed
-func (o *Operation) SwitchBackupEntryToTargetSeed(ctx context.Context) error {
-	var (
-		name              = common.GenerateBackupEntryName(o.Shoot.Info.Status.TechnicalID, o.Shoot.Info.Status.UID)
-		gardenBackupEntry = &gardencorev1beta1.BackupEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: o.Shoot.Info.Namespace,
-			},
-		}
-	)
-
-	return kutil.TryUpdate(ctx, retry.DefaultBackoff, o.K8sGardenClient.DirectClient(), gardenBackupEntry, func() error {
-		gardenBackupEntry.Spec.SeedName = o.Shoot.Info.Spec.SeedName
-		return nil
-	})
-}
-
 // ComputeGrafanaHosts computes the host for both grafanas.
 func (o *Operation) ComputeGrafanaHosts() []string {
 	return []string{

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -83,17 +83,19 @@ type Shoot struct {
 
 // Components contains different components deployed in the Shoot cluster.
 type Components struct {
-	BackupEntry      component.DeployWaiter
-	ClusterIdentity  component.Deployer
-	Extensions       *Extensions
-	ControlPlane     *ControlPlane
-	SystemComponents *SystemComponents
+	BackupEntry       component.DeployWaiter
+	SourceBackupEntry component.DeployWaiter
+	ClusterIdentity   component.Deployer
+	Extensions        *Extensions
+	ControlPlane      *ControlPlane
+	SystemComponents  *SystemComponents
 }
 
 // ControlPlane contains references to K8S control plane components.
 type ControlPlane struct {
 	EtcdMain              etcd.Etcd
 	EtcdEvents            etcd.Etcd
+	EtcdForCopy           etcd.Etcd
 	KubeAPIServerService  component.DeployWaiter
 	KubeAPIServerSNI      component.DeployWaiter
 	KubeAPIServerSNIPhase component.Phase

--- a/vendor/github.com/gardener/etcd-druid/api/v1alpha1/etcd_types.go
+++ b/vendor/github.com/gardener/etcd-druid/api/v1alpha1/etcd_types.go
@@ -75,6 +75,9 @@ type BackupSpec struct {
 	// Image defines the etcd container image and tag
 	// +optional
 	Image *string `json:"image,omitempty"`
+	// SourceStore defines the specification of object store provider for storing backups.
+	// +optional
+	SourceStore *StoreSpec `json:"sourceStore,omitempty"`
 	// Store defines the specification of object store provider for storing backups.
 	// +optional
 	Store *StoreSpec `json:"store,omitempty"`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:
Modifies the migration and restoration flows so that 2 backupentries are deployed - one to be used as the source by the backup copy operation, the other for the destination.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
