### PR TITLE
Fixing ExtractShootDetailsFromBackupEntryName() to ignore source prefix

### DIFF
--- a/extensions/pkg/controller/backupentry/util.go
+++ b/extensions/pkg/controller/backupentry/util.go
@@ -18,8 +18,11 @@ import (
 	"strings"
 )
 
+const SourcePrefix = "source-"
+
 // ExtractShootDetailsFromBackupEntryName returns Shoot resource technicalID its UID from provided <backupEntryName>.
 func ExtractShootDetailsFromBackupEntryName(backupEntryName string) (shootTechnicalID, shootUID string) {
+	backupEntryName = strings.TrimPrefix(backupEntryName, SourcePrefix)
 	tokens := strings.Split(backupEntryName, "--")
 	shootUID = tokens[len(tokens)-1]
 	shootTechnicalID = strings.TrimSuffix(backupEntryName, "--"+shootUID)

--- a/extensions/pkg/controller/backupentry/util_test.go
+++ b/extensions/pkg/controller/backupentry/util_test.go
@@ -33,5 +33,6 @@ var _ = Describe("Util", func() {
 		Entry("with old shoot technical ID", "shoot-dev-example--f6c6fca8-9c99-11e9-829b-2a33b5079af0", "shoot-dev-example", "f6c6fca8-9c99-11e9-829b-2a33b5079af0"),
 		Entry("with new shoot technical ID", "shoot--dev--example--f6c6fca8-9c99-11e9-829b-2a33b5079af0", "shoot--dev--example", "f6c6fca8-9c99-11e9-829b-2a33b5079af0"),
 		Entry("without -- deliminator", "shoot-dev-example-f6c6fca8-9c99-11e9-829b-2a33b5079af0", "shoot-dev-example-f6c6fca8-9c99-11e9-829b-2a33b5079af0", "shoot-dev-example-f6c6fca8-9c99-11e9-829b-2a33b5079af0"),
+		Entry("with source- prefix", "source-shoot--dev--example--f6c6fca8-9c99-11e9-829b-2a33b5079af0", "shoot--dev--example", "f6c6fca8-9c99-11e9-829b-2a33b5079af0"),
 	)
 })

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -45,6 +45,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const SourcePrefix = "source-"
+
 // GetSecretKeysWithPrefix returns a list of keys of the given map <m> which are prefixed with <kind>.
 func GetSecretKeysWithPrefix(kind string, m map[string]*corev1.Secret) []string {
 	var result []string
@@ -114,6 +116,7 @@ func GenerateBackupEntryName(seedNamespace string, shootUID types.UID) string {
 
 // ExtractShootDetailsFromBackupEntryName returns Shoot resource technicalID its UID from provided <backupEntryName>.
 func ExtractShootDetailsFromBackupEntryName(backupEntryName string) (shootTechnicalID, shootUID string) {
+	backupEntryName = strings.TrimPrefix(backupEntryName, SourcePrefix)
 	tokens := strings.Split(backupEntryName, "--")
 	shootUID = tokens[len(tokens)-1]
 	shootTechnicalID = strings.TrimSuffix(backupEntryName, shootUID)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing ExtractShootDetailsFromBackupEntryName() to ignore source prefix
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
