### PR TITLE
Adapt migrate flow to initiate a copy operation

### DIFF
--- a/pkg/operation/botanist/component/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry.go
@@ -178,7 +178,15 @@ func (b *backupEntry) Wait(ctx context.Context) error {
 }
 
 // Destroy is not implemented yet.
-func (b *backupEntry) Destroy(_ context.Context) error { return nil }
+func (b *backupEntry) Destroy(ctx context.Context) error {
+	backupEntry := &gardencorev1beta1.BackupEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.values.Name,
+			Namespace: b.values.Namespace,
+		},
+	}
+	return client.IgnoreNotFound(b.client.Delete(ctx, backupEntry))
+}
 
 // WaitCleanup is not implemented yet.
 func (b *backupEntry) WaitCleanup(_ context.Context) error { return nil }

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -1011,7 +1011,7 @@ var _ = Describe("Etcd", func() {
 
 	Describe("#Snapshot", func() {
 		It("should return an error when the backup config is nil", func() {
-			Expect(etcd.Snapshot(ctx, nil)).To(MatchError(ContainSubstring("no backup is configured")))
+			Expect(etcd.CopyOperation(ctx, nil)).To(MatchError(ContainSubstring("no backup is configured")))
 		})
 
 		Context("w/ backup configuration", func() {
@@ -1057,10 +1057,10 @@ var _ = Describe("Etcd", func() {
 					podName,
 					"backup-restore",
 					"/bin/sh",
-					"curl -k https://etcd-"+testRole+"-local:8080/snapshot/full",
+					"curl -k https://etcd-"+testRole+"-local:8080/object/copyop",
 				)
 
-				Expect(etcd.Snapshot(ctx, podExecutor)).To(Succeed())
+				Expect(etcd.CopyOperation(ctx, podExecutor)).To(Succeed())
 			})
 
 			It("should return an error when the pod listing fails", func() {
@@ -1071,7 +1071,7 @@ var _ = Describe("Etcd", func() {
 					client.MatchingLabelsSelector{Selector: selector},
 				).Return(fakeErr)
 
-				Expect(etcd.Snapshot(ctx, podExecutor)).To(MatchError(fakeErr))
+				Expect(etcd.CopyOperation(ctx, podExecutor)).To(MatchError(fakeErr))
 			})
 
 			It("should return an error when the pod list is empty", func() {
@@ -1089,7 +1089,7 @@ var _ = Describe("Etcd", func() {
 					},
 				)
 
-				Expect(etcd.Snapshot(ctx, podExecutor)).To(MatchError(ContainSubstring("didn't find any pods")))
+				Expect(etcd.CopyOperation(ctx, podExecutor)).To(MatchError(ContainSubstring("didn't find any pods")))
 			})
 
 			It("should return an error when the pod list is too large", func() {
@@ -1112,7 +1112,7 @@ var _ = Describe("Etcd", func() {
 					},
 				)
 
-				Expect(etcd.Snapshot(ctx, podExecutor)).To(MatchError(ContainSubstring("multiple ETCD Pods found")))
+				Expect(etcd.CopyOperation(ctx, podExecutor)).To(MatchError(ContainSubstring("multiple ETCD Pods found")))
 			})
 
 			It("should return an error when the execution command fails", func() {
@@ -1143,10 +1143,10 @@ var _ = Describe("Etcd", func() {
 					podName,
 					"backup-restore",
 					"/bin/sh",
-					"curl -k https://etcd-"+testRole+"-local:8080/snapshot/full",
+					"curl -k https://etcd-"+testRole+"-local:8080/object/copyop",
 				).Return(nil, fakeErr)
 
-				Expect(etcd.Snapshot(ctx, podExecutor)).To(MatchError(fakeErr))
+				Expect(etcd.CopyOperation(ctx, podExecutor)).To(MatchError(fakeErr))
 			})
 		})
 	})

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -51,6 +51,20 @@ func (mr *MockEtcdMockRecorder) AlertingRules() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlertingRules", reflect.TypeOf((*MockEtcd)(nil).AlertingRules))
 }
 
+// CopyOperation mocks base method.
+func (m *MockEtcd) CopyOperation(arg0 context.Context, arg1 kubernetes.PodExecutor) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyOperation", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CopyOperation indicates an expected call of CopyOperation.
+func (mr *MockEtcdMockRecorder) CopyOperation(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyOperation", reflect.TypeOf((*MockEtcd)(nil).CopyOperation), arg0, arg1)
+}
+
 // Deploy mocks base method.
 func (m *MockEtcd) Deploy(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -154,20 +168,6 @@ func (m *MockEtcd) SetSourceBackupConfig(arg0 *etcd.BackupConfig) {
 func (mr *MockEtcdMockRecorder) SetSourceBackupConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSourceBackupConfig", reflect.TypeOf((*MockEtcd)(nil).SetSourceBackupConfig), arg0)
-}
-
-// Snapshot mocks base method.
-func (m *MockEtcd) Snapshot(arg0 context.Context, arg1 kubernetes.PodExecutor) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Snapshot", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Snapshot indicates an expected call of Snapshot.
-func (mr *MockEtcdMockRecorder) Snapshot(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockEtcd)(nil).Snapshot), arg0, arg1)
 }
 
 // Wait mocks base method.

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -186,9 +186,9 @@ func (b *Botanist) WaitUntilEtcdsReady(ctx context.Context) error {
 	)
 }
 
-// SnapshotEtcd executes into the etcd-main pod and triggers a full snapshot.
-func (b *Botanist) SnapshotEtcd(ctx context.Context) error {
-	return b.Shoot.Components.ControlPlane.EtcdMain.Snapshot(ctx, kubernetes.NewPodExecutor(b.K8sSeedClient.RESTConfig()))
+// InitiateETCDCopyOperation executes into the etcd-main pod and initiates a copy operation.
+func (b *Botanist) InitiateETCDCopyOperation(ctx context.Context) error {
+	return b.Shoot.Components.ControlPlane.EtcdMain.CopyOperation(ctx, kubernetes.NewPodExecutor(b.K8sSeedClient.RESTConfig()))
 }
 
 // ScaleETCDToZero scales ETCD main and events replicas to zero.


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adapts the migrate flow to initiate a copy operation instead of taking a snapshot. 
* Adjusts conditions for etcd-related tasks
* Implements Destroy for backupentry component

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
